### PR TITLE
Use string lengths and read chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ and associative Arrays for the root object.
 See http://php.net/serialize and http://php.net/unserialize for
 details on the PHP side of all this.
 
+## Why this fork?
+
+This fork was created to work with other applications that use string length instead of bytesize when serializing strings in PHP. Only use this fork if this applies to your project.
+
 ## Acknowledgements
 
 - TJ Vanderpoel, initial PHP serialized session support.

--- a/lib/php/serialize/version.rb
+++ b/lib/php/serialize/version.rb
@@ -1,5 +1,5 @@
 module PHP
   module Serialize
-    VERSION = "1.2.0"
+    VERSION = "1.3.0"
   end
 end

--- a/lib/php_serialize.rb
+++ b/lib/php_serialize.rb
@@ -7,10 +7,14 @@ module PHP
 		# Reads data from the buffer until +char+ is found. The
 		# returned string will include +char+.
 		def read_until(char)
-			val, cpos = '', pos
-			if idx = string.index(char, cpos)
-				val = read(idx - cpos + 1)
+			val = ''
+
+			while next_char = getc
+				val << next_char
+
+				break if next_char == char
 			end
+
 			val
 		end
 	end
@@ -61,7 +65,7 @@ module PHP
 				s << '}'
 
 			when String, Symbol
-				s << "s:#{var.to_s.bytesize}:\"#{var.to_s}\";"
+				s << "s:#{var.to_s.length}:\"#{var.to_s}\";"
 
 			when Fixnum # PHP doesn't have bignums
 				s << "i:#{var};"
@@ -244,8 +248,13 @@ module PHP
 				end
 
 			when 's' # string, s:length:"data";
-				len = string.read_until(':').to_i + 3 # quotes, separator
-				val = string.read(len)[1...-2] # read it, kill useless quotes
+				len = string.read_until(':').to_i
+				string.read(1) # skip quote
+
+				val = ''
+				len.times { val << string.getc }
+
+				string.read(2) # skip quote and semi-colon
 
 			when 'i' # integer, i:123
 				val = string.read_until(';').to_i

--- a/test/php_serialize_test.rb
+++ b/test/php_serialize_test.rb
@@ -63,6 +63,7 @@ class TestPhpSerialize < Test::Unit::TestCase
 	test(-2147483648, "i:-2147483648;", :name => 'Min Fixnum')
 	test 4.2, 'd:4.2;'
 	test 'test', 's:4:"test";'
+	test 'åäö', 's:3:"åäö";'
 	test :test, 's:4:"test";', :name => 'Symbol'
 	test "\"\n\t\"", "s:4:\"\"\n\t\"\";", :name => 'Complex string'
 	test [nil, true, false, 42, 4.2, 'test'], 'a:6:{i:0;N;i:1;b:1;i:2;b:0;i:3;i:42;i:4;d:4.2;i:5;s:4:"test";}',
@@ -75,7 +76,7 @@ class TestPhpSerialize < Test::Unit::TestCase
 
   # PHP counts multibyte string, not string length
   def test_multibyte_string
-    assert_equal  "s:6:\"öäü\";", PHP.serialize("öäü")
+    assert_equal  "s:3:\"öäü\";", PHP.serialize("öäü")
   end
 	# Verify assoc is passed down calls.
 	# Slightly awkward because hashes don't guarantee order.


### PR DESCRIPTION
Strings will now be serialized as `s:#{string.length}:"#{string}";`

For example:

```ruby
PHP.serialize('hello') => 's:5:"hello";'
PHP.serialize('hallå') => 's:5:"hallå";'
```

Unserializing strings will read `length` chars to allow for both ASCII and 2 byte Unicode characters.

For example:

```ruby
PHP.unserialize('s:5:"hello";') => 'hello'
PHP.unserialize('s:5:"hallå";') => 'hallå'
```