### PR TITLE
Support php5 and php6

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ details on the PHP side of all this.
 
 ## Why this fork?
 
-This fork was created to work with other applications that use string length instead of bytesize when serializing strings in PHP. Only use this fork if this applies to your project.
+This fork was created to work with other applications that uses both PHP5 and PHP6 meaning we must be able to unserialize strings given in either bytesize or charsize. Only use this fork if this applies to your project.
 
 ## Acknowledgements
 

--- a/lib/php/serialize/version.rb
+++ b/lib/php/serialize/version.rb
@@ -1,5 +1,5 @@
 module PHP
   module Serialize
-    VERSION = "1.3.1"
+    VERSION = "1.3.2"
   end
 end

--- a/test/php_serialize_test.rb
+++ b/test/php_serialize_test.rb
@@ -63,7 +63,8 @@ class TestPhpSerialize < Test::Unit::TestCase
 	test(-2147483648, "i:-2147483648;", :name => 'Min Fixnum')
 	test 4.2, 'd:4.2;'
 	test 'test', 's:4:"test";'
-	test 'åäö', 's:3:"åäö";'
+	test 'åäöåäö', 's:12:"åäöåäö";'
+	test ['hallå', 'hallå', 'hej'], 'a:3:{i:0;s:6:"hallå";i:1;s:6:"hallå";i:2;s:3:"hej";}'
 	test :test, 's:4:"test";', :name => 'Symbol'
 	test "\"\n\t\"", "s:4:\"\"\n\t\"\";", :name => 'Complex string'
 	test [nil, true, false, 42, 4.2, 'test'], 'a:6:{i:0;N;i:1;b:1;i:2;b:0;i:3;i:42;i:4;d:4.2;i:5;s:4:"test";}',
@@ -76,7 +77,7 @@ class TestPhpSerialize < Test::Unit::TestCase
 
   # PHP counts multibyte string, not string length
   def test_multibyte_string
-    assert_equal  "s:3:\"öäü\";", PHP.serialize("öäü")
+    assert_equal "s:6:\"öäü\";", PHP.serialize("öäü")
   end
 	# Verify assoc is passed down calls.
 	# Slightly awkward because hashes don't guarantee order.
@@ -93,6 +94,13 @@ class TestPhpSerialize < Test::Unit::TestCase
 			unserialized = PHP.unserialize(serialized, true)
 			assert_equal ruby_assoc.sort, unserialized.sort
 		end
+	end
+
+	def test_php_versions
+		assert_equal ['ååååå', 'ååååå', 'hej'], PHP.unserialize('a:3:{i:0;s:5:"ååååå";i:1;s:5:"ååååå";i:2;s:3:"hej";}')
+		assert_equal ['ååååå', 'ååååå', 'hej'], PHP.unserialize('a:3:{i:0;s:5:"ååååå";i:1;s:10:"ååååå";i:2;s:3:"hej";}')
+		assert_equal ['ååååå', 'ååååå', 'hej'], PHP.unserialize('a:3:{i:0;s:10:"ååååå";i:1;s:5:"ååååå";i:2;s:3:"hej";}')
+		assert_equal ['ååååå', 'ååååå', 'hej'], PHP.unserialize('a:3:{i:0;s:10:"ååååå";i:1;s:10:"ååååå";i:2;s:3:"hej";}')
 	end
 
 	def test_sessions


### PR DESCRIPTION
The following changes will apply:
```ruby
# String can be sized in either bytes or chars when unserialized
PHP.unserialze('s:6:"åäö";') => 'åäö'
PHP.unserialze('s:3:"åäö";') => 'åäö'

# Strings will be sized using bytes when serialized
PHP.serialze('åäö') => 's:6:"åäö";'
```
