### PR TITLE
Ruby 2.4.0 compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.3 2018-05-14
+- Ruby 2.4.0 compliance.
+
 ## 1.3.0 2017-07-29
 - Add support for parsing both PHP5 and PHP6 generated objects.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.0 2017-07-29
+- Add support for parsing both PHP5 and PHP6 generated objects.
+
 ## 1.2.0 2017-06-29
 - Special require option no longer needed for Bundler
 - Warnings fixes on JRuby

--- a/lib/php/serialize/version.rb
+++ b/lib/php/serialize/version.rb
@@ -1,5 +1,5 @@
 module PHP
   module Serialize
-    VERSION = "1.3.2"
+    VERSION = "1.3.3"
   end
 end

--- a/lib/php_serialize.rb
+++ b/lib/php_serialize.rb
@@ -32,7 +32,7 @@ module PHP
 	#
 	#   string = PHP.serialize(mixed var[, bool assoc])
 	#
-	# Array, Hash, Fixnum, Float, True/FalseClass, NilClass, String and Struct
+	# Array, Hash, Integer, Float, True/FalseClass, NilClass, String and Struct
 	# are supported; as are objects which support the to_assoc method, which
 	# returns an array of the form [['attr_name', 'value']..].  Anything else
 	# will raise a TypeError.
@@ -75,7 +75,7 @@ module PHP
 			when String, Symbol
 				s << "s:#{var.to_s.bytesize}:\"#{var.to_s}\";"
 
-			when Fixnum # PHP doesn't have bignums
+			when Integer # PHP doesn't have bignums
 				s << "i:#{var};"
 
 			when Float
@@ -159,7 +159,7 @@ module PHP
 	# each serialized attribute is sent to the new object using the respective
 	# {attribute}=() method; you'll get a NameError if the method doesn't exist.
 	#
-	# Array, Hash, Fixnum, Float, True/FalseClass, NilClass and String should
+	# Array, Hash, Integer, Float, True/FalseClass, NilClass and String should
 	# be returned identically (i.e. foo == PHP.unserialize(PHP.serialize(foo))
 	# for these types); Struct should be too, provided it's in the namespace
 	# Module.const_get within unserialize() can see, or you gave it the same


### PR DESCRIPTION
Removes deprecation:

    php-serialize/lib/php_serialize.rb:78: warning: constant ::Fixnum is deprecated

After:
![image](https://user-images.githubusercontent.com/7694080/40020785-45d196f2-57c3-11e8-9afe-48cecf8ccbe5.png)
